### PR TITLE
Fixed ZED_SESSION_REDIS_SCHEME typo in the redis constants

### DIFF
--- a/src/Spryker/Shared/SessionRedis/SessionRedisConstants.php
+++ b/src/Spryker/Shared/SessionRedis/SessionRedisConstants.php
@@ -142,7 +142,7 @@ interface SessionRedisConstants
      *
      * @api
      *
-     * @deprecated Use {@link \Spryker\Shared\SessionRedis\SessionRedisConstants::ZED_SESSION_REDIS_PROTOCOL} instead.
+     * @deprecated Use {@link \Spryker\Shared\SessionRedis\SessionRedisConstants::ZED_SESSION_REDIS_SCHEME} instead.
      *
      * @var string
      */


### PR DESCRIPTION
## PR Description

Fixed a little typo